### PR TITLE
Uncomment DebugPanel to make it visible again

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,8 +43,7 @@ function App() {
         <Route path="/about" element={<About />} />
       </Routes>
       <Footer />
-      {/* <DebugPanel /> */}
-      {/* Debug panel hidden in production - uncomment for development */}
+      <DebugPanel />
     </Router>
   )
 }


### PR DESCRIPTION
The debug panel was previously commented out in App.jsx.
This change restores its visibility for development use.